### PR TITLE
修复因 `json` 格式不规范 导致首页无法正常加载的 `bug`

### DIFF
--- a/data.json
+++ b/data.json
@@ -172,7 +172,7 @@
     { "name": "林羽凡网", "url": "https://www.linyufan.com/", "tag": "生活,记事,小程序", "sign": "勤勤恳恳写日记的普通人", "feed": "https://www.linyufan.com/rss.xml", "status": "ReadTimeout" },
     { "name": "阿呆博客-90后肥宅生活", "url": "https://bo.ke/", "tag": "数码,生活,记事", "sign": "90后肥宅生活", "feed": "https://bo.ke/feed/", "status": "SSLError" },
     { "name": "小灰狼", "url": "https://fly2lan.cc/", "tag": "音乐,Vlog,分享,生活,记事", "sign": "零零碎碎，记录喜怒哀乐", "feed": "https://fly2lan.cc/feed/", "status": "OK" },
-    { "name": "迟於", "url": "https://www.weingxing.cn/", "tag": "深度学习,算法,", "sign": "栖迟於一丘", "feed": "https://www.weingxing.cn/feed/", "status": "OK" },
+    { "name": "迟於", "url": "https://www.weingxing.cn/", "tag": "深度学习,算法", "sign": "栖迟於一丘", "feed": "https://www.weingxing.cn/feed/", "status": "OK" },
     { "name": "杜郎俊赏", "url": "https://dujun.io/", "tag": "生活,记事,理财", "sign": "", "feed": "https://dujun.io/feed/", "status": "OK" },
     { "name": "白云苍狗", "url": "https://www.imalun.com/", "tag": "Vue,文学,VS Code插件,数据库", "sign": "好好生活，好好工作，好好记录。每天多一点思考，每天就会多一点成长。", "status": "OK" },
     { "name": "威言威语", "url": "https://www.weisay.com/blog/", "tag": "分享,数码,生活", "sign": "我愿像茶一样，把苦涩留在心里，敬发出来的都是清香！", "status": "OK" },


### PR DESCRIPTION
`tag` 多填了一个逗号

```
-    { "name": "迟於", "url": "https://www.weingxing.cn/", "tag": "深度学习,算法,", "sign": "栖迟於一丘", "feed": "https://www.weingxing.cn/feed/", "status": "OK" },
+    { "name": "迟於", "url": "https://www.weingxing.cn/", "tag": "深度学习,算法", "sign": "栖迟於一丘", "feed": "https://www.weingxing.cn/feed/", "status": "OK" },
```


经过排查，问题出现在此次提交

[为170~190号站点贴了标签](https://github.com/zh-blogs/blog-daohang/commit/2cd2fd3d3a7363fc104aeb74e6919b9995b82859)

产生原因为：

- 在添加标签时误添加了多余的逗号，导致 `json` 不能被正常读取，报错页面如下

  ![Snipaste_2022-04-09_08-23-43](https://user-images.githubusercontent.com/62864752/162548983-a19c1c3a-a984-45e6-8f53-fc13eeb55f1e.png)

受到影响的链接：

- https://zhblogs.ohyee.cc
