### PR TITLE
删除“博客头像”“联系邮箱”字段

### DIFF
--- a/pages/manager/join.tsx
+++ b/pages/manager/join.tsx
@@ -25,7 +25,7 @@ export default function AddBlog() {
           key: 'url',
           label: '博客首页',
           required: true,
-          placeholder: '贵博客的域名',
+          placeholder: '贵博客的域名（带http(s)://）',
           rules: [
             {
               validator: async (_, value) => {
@@ -60,19 +60,9 @@ export default function AddBlog() {
           placeholder: '贵博客的一句话描述',
         },
         {
-          key: 'logo',
-          label: '博客头像',
-          placeholder: '如果可以的话，为我们提供一个 logo 文件',
-        },
-        {
           key: 'feed',
           label: 'RSS 订阅地址',
           placeholder: '如果可以的话，为我们提供一个 RSS 订阅链接',
-        },
-        {
-          key: 'email',
-          label: '联系邮箱',
-          placeholder: '您的联系邮箱，我们可能会使用此邮箱联系您'
         },
         {
           key: 'sitemap',


### PR DESCRIPTION
相关的 key 已在 https://github.com/zh-blogs/blog-daohang/commit/3f2c21816045c8e3609743481172c250c25b32b0 被删除。